### PR TITLE
Improve discussions analytics

### DIFF
--- a/core/client/peer.js
+++ b/core/client/peer.js
@@ -5,7 +5,7 @@ peer = {
   calls: {},
   callsToClose: {},
   callsOpening: {},
-  discussionStartDate: undefined,
+  callStartDates: {},
   remoteCalls: {},
   peerInstance: undefined,
   peerLoading: false,
@@ -90,12 +90,12 @@ peer = {
 
     if (!this.hasActiveStreams()) {
       userStreams.destroyStream(streamTypes.main);
+    }
 
-      if (this.discussionStartDate) {
-        const duration = (Date.now() - this.discussionStartDate) / 1000;
-        Meteor.call('analyticsDiscussionEnd', { duration });
-        this.discussionStartDate = undefined;
-      }
+    if (this.callStartDates[userId]) {
+      const duration = (Date.now() - this.callStartDates[userId]) / 1000;
+      Meteor.call('analyticsDiscussionEnd', { peerUserId: userId, duration, usersAttendingCount: this.getCallCount() });
+      delete this.callStartDates[userId];
     }
 
     $(`.js-video-${userId}-user`).remove();
@@ -156,9 +156,9 @@ peer = {
       audioManager.play('webrtc-in.mp3', 0.2);
       notify(user, `Wants to talk to you`);
 
-      if (!this.hasActiveStreams() && !this.discussionStartDate) {
-        this.discussionStartDate = new Date();
-        Meteor.call('analyticsDiscussionAttend', { users_attending_count: userProximitySensor.nearUsersCount() });
+      if (!this.callStartDates[user._id]) {
+        this.callStartDates[user._id] = Date.now();
+        Meteor.call('analyticsDiscussionAttend', { peerUserId: user._id, usersAttendingCount: this.getCallCount() });
       }
     }
 
@@ -491,6 +491,10 @@ peer = {
   unlockCall(userId, notify = false) {
     if (notify && this.lockedCalls[userId]) this.sendData([userId], { type: 'unfollowed', emitter: Meteor.userId() });
     delete this.lockedCalls[userId];
+  },
+
+  getCallCount() {
+    return Object.keys(this.callStartDates).length;
   },
 
   hasActiveStreams() {

--- a/core/server/analytics.js
+++ b/core/server/analytics.js
@@ -122,22 +122,34 @@ Meteor.methods({
     if (!userId) return;
 
     check(traits, {
-      users_attending_count: Number,
+      peerUserId: String,
+      usersAttendingCount: Number,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion Attend', { level_id: user.profile.levelId });
+    analytics.track(userId, '💬 Discussion Attend', {
+      level_id: user.profile.levelId,
+      peer_user_id: traits.peerUserId,
+      users_attending_count: traits.usersAttendingCount,
+    });
   },
   analyticsDiscussionEnd(traits) {
     const { userId } = this;
     if (!userId) return;
 
     check(traits, {
+      usersAttendingCount: Number,
       duration: Number,
+      peerUserId: String,
     });
 
     const user = Meteor.user();
-    analytics.track(userId, '💬 Discussion End', { level_id: user.profile.levelId, duration: traits.duration });
+    analytics.track(userId, '💬 Discussion End', {
+      level_id: user.profile.levelId,
+      duration: traits.duration,
+      users_attending_count: traits.usersAttendingCount,
+      peer_user_id: traits.peerUserId,
+    });
   },
   analyticsConferenceAttend(traits) {
     const { userId } = this;


### PR DESCRIPTION
`DiscussionAttend` and `DiscussionEnd` events are now thrown also when a user joins or leaves an existing discussion.

`users_attending_count`: This property allows to know how many users were in the discussions before the join/left and thus allows to filter new discussions/discussions ending if needed.

`peer_user_id`: The user id of the user joining/leaving the discussion.

The choice of throwing the same events with a `users_attending_count` rather than new events (e.g. `DiscussionJoin`, `DiscussionLeft`) is because it is easier in most analytics tools to filter on properties rather than aggregating events.