### PR TITLE
Rework the login container when account creation is disabled

### DIFF
--- a/core/client/ui/form-account.hbs.html
+++ b/core/client/ui/form-account.hbs.html
@@ -1,6 +1,6 @@
 <template name="formAccount">
-  {{#if showLogForm}}
-    {{> formLogIn visible=isLoading}}
+  {{#if (or showLogForm restrictedRegistration)}}
+    {{> formLogIn visible=isLoading restrictedRegistration=restrictedRegistration}}
   {{else if not restrictedRegistration}}
     {{> formSignIn visible=isLoading}}
   {{else}}

--- a/core/client/ui/form-account.js
+++ b/core/client/ui/form-account.js
@@ -1,13 +1,9 @@
 import { toggleUIInputs } from '../helpers';
 
 Template.formAccount.helpers({
-  showLogForm() { FlowRouter.watchPathChange(); return FlowRouter.current().queryParams.mode === 'login'; },
+  showLogForm() { FlowRouter.watchPathChange(); return FlowRouter.current().queryParams.mode === 'grc'; },
   restrictedRegistration() {
     const { permissions } = Meteor.settings.public;
-    if (!permissions) return false;
-
-    if (!permissions.contactURL?.length) return false;
-    if (permissions.allowAccountCreation === 'all') return false;
 
     if (permissions.allowAccountCreation === 'none') return true;
     if (permissions.allowAccountCreation.includes('except:')) {

--- a/core/client/ui/form-log-in.hbs.html
+++ b/core/client/ui/form-log-in.hbs.html
@@ -1,6 +1,11 @@
 <template name="formLogIn">
   <div class="form-account {{#unless visible}}visible{{/unless}}">
-    <h1 class="title">Log to my account</h1>
+    {{#if restrictedRegistration}}
+      <h1 class="title">Welcome to lemverse</h1>
+      <h2 class="title">Log to my account</h2>
+    {{else}}
+      <h1 class="title">Log to my account or create a new one</h1>
+    {{/if}}
     <div class="step">
       <form>
         <div class="group-field">
@@ -21,10 +26,14 @@
     </div>
 
     <div class="bottom">
-      {{#if loginMode}}
-        <a href="?mode=create" class="link">Missing an account, join there!</a>
-      {{else}}
-        <button type="button" class="link js-cancel-login-mode" aria-label="cancel">Cancel</button>
+      {{#if not restrictedRegistration}}
+        {{#if loginMode}}
+          <a href="?mode=create" class="link">Missing an account, join there!</a>
+        {{else}}
+          <button type="button" class="link js-cancel-login-mode" aria-label="cancel">Cancel</button>
+        {{/if}}
+      {{else if contactURL}}
+          <p><a href="{{contactURL}}" target="_blank" rel="noopener">Contact us</a> to create your own customized virtual office on lemverse</p>
       {{/if}}
     </div>
   </div>

--- a/core/client/ui/form-log-in.js
+++ b/core/client/ui/form-log-in.js
@@ -69,4 +69,5 @@ Template.formLogIn.helpers({
   email() { return Template.instance().email; },
   password() { return Template.instance().password; },
   loginMode() { return Template.instance().loginMode.get(); },
-});
+  contactURL() { return Meteor.settings.public.permissions?.contactURL; }},  
+);

--- a/core/client/ui/form-sign-in-limited.hbs.html
+++ b/core/client/ui/form-sign-in-limited.hbs.html
@@ -1,8 +1,0 @@
-<template name="formSignInLimited">
-  <div class="form-account {{#unless visible}}visible{{/unless}}">
-    <h1 class="title">Request Access</h1>
-    <p><a href="{{contactURL}}" target="_blank" rel="noopener">Contact us</a> to create your own customized virtual office on lemverse</p>
-    <br />
-    <a href="?mode=login" class="link">I already have an account</a>
-  </div>
-</template>

--- a/core/client/ui/form-sign-in-limited.js
+++ b/core/client/ui/form-sign-in-limited.js
@@ -1,3 +1,0 @@
-Template.formSignInLimited.helpers({
-  contactURL() { return Meteor.settings.public.permissions?.contactURL; },
-});


### PR DESCRIPTION
When `public.lp.permissions.allowAccountCreation` is `"none"`, the login form currently looks like this:

<img width="674" alt="image" src="https://user-images.githubusercontent.com/835072/185638808-0fd0d1cd-1d1a-47d6-ae59-fa825877a178.png">

With this PR applied, it now looks that way:

<img width="685" alt="image" src="https://user-images.githubusercontent.com/835072/185639140-682f0b47-44b9-40cf-8c82-fa2194c0cfc3.png">

Also, if you don't specify a `public.lp.permissions.contactURL`, then `allowAccountCreation` is currently ignored. With this PR applied, it applies but just don't show the "Contact us" message:

<img width="682" alt="image" src="https://user-images.githubusercontent.com/835072/185639521-b9b7ac9e-43a1-43d8-adf1-e721c393ad4e.png">