### PR TITLE
Add possibility to override Jitsi meet config options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+# History
+.history

--- a/app/_settings.json
+++ b/app/_settings.json
@@ -32,7 +32,12 @@
 
     "meet": {
       "serverURL": "meet.jit.si",
-      "roomDefaultName": "lemverse-test"
+      "roomDefaultName": "lemverse-test",
+      "configOverwrite": {
+        "prejoinConfig": {
+          "enabled": false
+        }
+      }
     },
 
     "character": {

--- a/app/settings-dev.json
+++ b/app/settings-dev.json
@@ -32,7 +32,12 @@
 
     "meet": {
       "serverURL": "meet.jit.si",
-      "roomDefaultName": "lemverse-test"
+      "roomDefaultName": "lemverse-test",
+      "configOverwrite": {
+        "prejoinConfig": {
+          "enabled": false
+        }
+      }
     },
 
     "character": {

--- a/core/modules/meet/client/meet.js
+++ b/core/modules/meet/client/meet.js
@@ -97,7 +97,8 @@ meetHighLevel = {
     if (meet.api) return;
 
     const user = Meteor.user();
-    const currentZone = zoneManager.currentZone();
+    const currentZone = zones.currentZone();
+    const configOverwrite = Meteor.settings.public.meet.configOverwrite || {};
 
     const options = {
       width: '100%',
@@ -111,6 +112,7 @@ meetHighLevel = {
         startWithAudioMuted: !currentZone.unmute,
         startWithVideoMuted: !currentZone.unhide,
         disableTileView: !currentZone.unhide,
+        ...configOverwrite,
       },
       roomName: config.roomName,
       jwt: config.token,


### PR DESCRIPTION
Actually we can't override Jitsi meet options as we can found them here : https://github.com/jitsi/jitsi-meet/blob/master/config.js

I've added a simple solution to override it dynamically. 