### PR TITLE
Fix tilesets bug having same gid

### DIFF
--- a/core/client/ui/editor-tilesets.js
+++ b/core/client/ui/editor-tilesets.js
@@ -137,7 +137,12 @@ Template.editorTilesets.events({
   },
   'drop .js-drop-tileset'({ originalEvent }) {
     const uploadedFiles = originalEvent.dataTransfer.files;
-    Array.from(uploadedFiles).forEach(file => {
+   
+    const maxTileset = Tilesets.findOne({}, { sort: { gid: -1 }, limit: 1 });
+    let maxTilesetGid = 0;
+    if (maxTileset) maxTilesetGid = maxTileset.gid + 10000;
+
+    Array.from(uploadedFiles).forEach((file, index) => {
       if (!file) return;
 
       const uploadInstance = Files.insert({
@@ -145,6 +150,7 @@ Template.editorTilesets.events({
         chunkSize: 'dynamic',
         meta: {
           source: 'editor-tilesets',
+          gid: maxTilesetGid,
         },
       }, false);
 
@@ -153,6 +159,7 @@ Template.editorTilesets.events({
       });
 
       uploadInstance.start();
+      maxTilesetGid += 10000;
     });
   },
   'mousemove img'(event) {

--- a/core/server/files.js
+++ b/core/server/files.js
@@ -31,12 +31,9 @@ const filesAfterUploadEditorTileset = (user, fileRef) => {
   } else {
     // Create
     log('filesAfterUploadEditorTileset: create a new tileset', { userId: user._id, fileId: fileRef._id });
-    const maxTileset = Tilesets.findOne({}, { sort: { gid: -1 }, limit: 1 });
-    let maxTilesetGid = 0;
-    if (maxTileset) maxTilesetGid = maxTileset.gid + 10000;
 
     const newId = Tilesets.id();
-    Tilesets.insert({ _id: newId, createdAt: new Date(), createdBy: user._id, name: fileRef.name, gid: maxTilesetGid, height, width, fileId: fileRef._id, fileName: fileRef.name });
+    Tilesets.insert({ _id: newId, createdAt: new Date(), createdBy: user._id, name: fileRef.name, gid: fileRef.meta.gid, height, width, fileId: fileRef._id, fileName: fileRef.name });
 
     log('filesAfterUploadEditorTileset: created tileset', { userId: user._id, tilesetId: newId });
   }


### PR DESCRIPTION
The issue : https://github.com/l3mpire/lemverse/issues/82#issuecomment-1225739298

This was due to asynchronous files uploading and inserting tileset with the same `gid` for some tilesets while they were added asynchronously. 

The solution was to iterate this `gid` before uploading the file, adding this `gid` to the file meta and getting it back when inserting the tileset on the 'afterUpload' event. 