### PR TITLE
Allows account deactivation

### DIFF
--- a/core/client/ui/form-log-in.js
+++ b/core/client/ui/form-log-in.js
@@ -31,11 +31,7 @@ const startRetryCountdown = template => {
 };
 
 const passwordlessLogin = template => {
-  const options = {
-    selector: template.email,
-    options: { userCreationDisabled: true },
-  };
-  Accounts.requestLoginTokenForUser(options, err => {
+  Meteor.call('requestLoginTokenForActiveUser', template.email, err => {
     if (err && err.message !== 'User not found [403]') {
       lp.notif.error(err.message);
       return;

--- a/core/server/accounts.js
+++ b/core/server/accounts.js
@@ -50,3 +50,14 @@ Accounts.validateLoginAttempt(param => {
 
   return true;
 });
+
+Meteor.methods({
+  requestLoginTokenForActiveUser: email => {
+    check(email, String);
+    const options = {
+      selector: { email },
+      options: { userCreationDisabled: true },
+    };
+    Meteor.call('requestLoginTokenForUser', options);
+  },
+});

--- a/core/server/accounts.js
+++ b/core/server/accounts.js
@@ -47,6 +47,10 @@ Accounts.validateLoginAttempt(param => {
     error('validateLoginAttempt: watched ip detected!', { ip: lp.ip(param).ip, userId: user?._id });
     return false;
   }
+  if (user?.disabled) {
+    log('validateLoginAttempt: user account is inactive', { userId: user?._id });
+    return false;
+  }
 
   return true;
 });
@@ -54,6 +58,8 @@ Accounts.validateLoginAttempt(param => {
 Meteor.methods({
   requestLoginTokenForActiveUser: email => {
     check(email, String);
+    const user = Meteor.users.findOne({ 'emails.address': email });
+    if (user?.disabled) return;
     const options = {
       selector: { email },
       options: { userCreationDisabled: true },


### PR DESCRIPTION
When a user has the `disabled` property, he cannot log-in nor receive passwordless emails.

The `Meteor.call('requestLoginTokenForUser', options);` on the server side is required because `requestLoginTokenForUser` is registered as a Meteor method in the `accounts-passwordless` package.
As stated in the `Meteor.call` documentation (https://docs.meteor.com/api/methods.html#Meteor-call), the call is performed synchronously as no callback is provided.