### PR TITLE
Add a name baseline

### DIFF
--- a/core/client/components/character-name-text.js
+++ b/core/client/components/character-name-text.js
@@ -1,26 +1,50 @@
 import Phaser from 'phaser';
 
-const style = {
+const nameStyle = {
   font: 'Verdana, "Times New Roman", Tahoma, serif',
   fontSize: 18,
   strokeColor: '#000',
   strokeSize: 3,
 };
 
+const baselineStyle = {
+  ...nameStyle,
+  fontSize: 12,
+};
+
 const defaultTint = 0xFFFFFF;
+const baselineOffset = 20;
 
-class CharacterNameText extends Phaser.GameObjects.Text {
-  constructor(scene, text, tintName) {
-    super(scene, 0, 0, text);
+class CharacterNameText {
+  constructor(scene, name, baseline, tintName) {
+    this.scene = scene;
+    this.name = this.createText(name, nameStyle);
+    this.setBaseline(baseline);
+    this.setTintFromName(tintName);
+  }
 
-    this.setFontFamily(style.font)
+  createText(message, style) {
+    const text = new Phaser.GameObjects.Text(this.scene, 0, 0, message);
+    text.setFontFamily(style.font)
       .setFontSize(style.fontSize)
       .setStroke(style.strokeColor, style.strokeSize)
       .setDepth(99999)
-      .setOrigin(0.5)
-      .setTintFromName(tintName);
+      .setOrigin(0.5);
 
-    this.scene.add.existing(this);
+    this.scene.add.existing(text);
+    return text;
+  }
+
+  setBaseline(text) {
+    if (!text) {
+      this.destroyBaseline();
+      return;
+    }
+    if (this.baseline) {
+      this.baseline.setText(text, baselineStyle);
+      return;
+    }
+    this.baseline = this.createText(text, baselineStyle);
   }
 
   setTintFromName(tintName) {
@@ -28,7 +52,34 @@ class CharacterNameText extends Phaser.GameObjects.Text {
     if (!colors) return this;
 
     const color = colors[tintName] || [defaultTint];
-    return this.setTint(...color);
+    this.name.setTint(...color);
+    if (this.baseline) {
+      this.baseline.setTint(...color);
+    }
+    return this;
+  }
+
+  setText(name, baseline) {
+    this.name.setText(name);
+    this.setBaseline(baseline);
+    return this;
+  }
+
+  setPosition(x, y) {
+    this.name.setPosition(x, this.baseline ? y - baselineOffset : y);
+    if (this.baseline) this.baseline.setPosition(x, y);
+  }
+
+  destroyBaseline() {
+    if (this.baseline) {
+      this.baseline.destroy();
+      this.baseline = undefined;
+    }
+  }
+
+  destroy() {
+    this.name.destroy();
+    this.destroyBaseline();
   }
 }
 

--- a/core/client/components/character.js
+++ b/core/client/components/character.js
@@ -150,8 +150,8 @@ class Character extends Phaser.GameObjects.Container {
     this.getByName('stateIndicator').visible = value;
   }
 
-  setName(name, color) {
-    game.scene.getScene('UIScene').updateUserName(this.getData('userId'), name, color);
+  setName(name, baseline, color) {
+    game.scene.getScene('UIScene').updateUserName(this.getData('userId'), name, baseline, color);
   }
 
   stopFollow() {

--- a/core/client/scenes/scene-ui.js
+++ b/core/client/scenes/scene-ui.js
@@ -106,17 +106,17 @@ UIScene = new Phaser.Class({
     });
   },
 
-  updateUserName(userId, name, colorName) {
+  updateUserName(userId, name, baseline, colorName) {
     let textInstance = this.characterNamesObjects[userId];
 
     if (!textInstance) {
       const player = userManager.getCharacter(userId);
       if (!player) return;
 
-      textInstance = new CharacterNameText(this, name, colorName);
+      textInstance = new CharacterNameText(this, name, baseline, colorName);
       textInstance.player = player;
       this.characterNamesObjects[userId] = textInstance;
-    } else if (textInstance) textInstance.setTintFromName(colorName).setText(name);
+    } else if (textInstance) textInstance.setTintFromName(colorName).setText(name, baseline);
   },
 
   destroyUserName(userId) {

--- a/core/client/ui/settings-basic.hbs.html
+++ b/core/client/ui/settings-basic.hbs.html
@@ -23,6 +23,11 @@
         <input type="text" name="name" id="name" class="js-name input" value="{{currentUser.profile.name}}">
       </div>
 
+      <div class="form-element-m">
+        <label for="baseline" class="label">Baseline</label>
+        <input type="text" name="baseline" id="baseline" class="js-name input" value="{{currentUser.profile.baseline}}">
+      </div>
+
       {{#if length nameColors}}
         <div class="form-element-m">
           <label for="name-color" class="label">Name color</label>

--- a/core/client/ui/settings-basic.js
+++ b/core/client/ui/settings-basic.js
@@ -12,7 +12,8 @@ const submit = template => {
     }
 
     const { profile } = user();
-    userManager.getControlledCharacter()?.setName(fields.name || profile.name, fields.nameColor || profile.nameColor);
+    userManager.getControlledCharacter()?.setName(fields.name || profile.name,
+      fields.baseline || profile.baseline, fields.nameColor || profile.nameColor);
     lp.notif.success('Account updated');
     template.hasUpdates.set(false);
     template.fieldsUpdated = {};

--- a/core/client/user-manager.js
+++ b/core/client/user-manager.js
@@ -60,7 +60,7 @@ userManager = {
   onDocumentAdded(user) {
     if (this.characters[user._id]) return null;
 
-    const { x, y, guest, direction, name, nameColor } = user.profile;
+    const { x, y, guest, direction, name, baseline, nameColor } = user.profile;
 
     const character = new Character(this.scene, x, y);
     character.setData('userId', user._id);
@@ -68,7 +68,7 @@ userManager = {
     this.characters[user._id] = character;
 
     if (guest) character.updateSkin(guestSkin()); // init with custom skin
-    else character.setName(name, nameColor);
+    else character.setName(name, baseline, nameColor);
 
     window.setTimeout(() => this.onDocumentUpdated(user), 0);
 
@@ -126,7 +126,7 @@ userManager = {
     const character = this.characters[user._id];
     if (!character) return;
 
-    const { x, y, direction, reaction, shareAudio, guest, userMediaError, name, nameColor } = user.profile;
+    const { x, y, direction, reaction, shareAudio, guest, userMediaError, name, baseline, nameColor } = user.profile;
 
     // update character instance
     character.direction = direction;
@@ -141,7 +141,7 @@ userManager = {
     // is account transformed from guest to user?
     if (!user.profile.guest && oldUser?.profile.guest) {
       character.toggleMouseInteraction(true);
-      character.setName(name, nameColor);
+      character.setName(name, baseline, nameColor);
     }
 
     // show reactions
@@ -158,8 +158,8 @@ userManager = {
     }
 
     // update name
-    const nameUpdated = !guest && (name !== oldUser?.profile.name || nameColor !== oldUser?.profile.nameColor);
-    if (nameUpdated) character.setName(name, nameColor);
+    const nameUpdated = !guest && (name !== oldUser?.profile.name || baseline !== oldUser?.profile.baseline || nameColor !== oldUser?.profile.nameColor);
+    if (nameUpdated) character.setName(name, baseline, nameColor);
 
     const userHasMoved = x !== oldUser?.profile.x || y !== oldUser?.profile.y;
     const loggedUser = Meteor.user();

--- a/core/server/users.js
+++ b/core/server/users.js
@@ -137,6 +137,7 @@ Meteor.methods({
       bio: Match.Optional(String),
       defaultReaction: Match.Optional(String),
       name: Match.Optional(String),
+      baseline: Match.Optional(String),
       nameColor: Match.Optional(String),
       website: Match.Optional(String),
     });


### PR DESCRIPTION
Add a new `Baseline` setting allowing to set a baseline with a smaller font size under the user name.

When provided:

<img width="324" alt="Screenshot 2022-09-06 at 16 19 19" src="https://user-images.githubusercontent.com/1092138/188659486-447ab645-ca2b-4fa6-a52e-ece1482050cc.png">
<img width="162" alt="Screenshot 2022-09-06 at 16 19 10" src="https://user-images.githubusercontent.com/1092138/188659512-650caa76-4cc4-4082-bcb6-9c7f702f6159.png">

When not provided:

<img width="333" alt="Screenshot 2022-09-06 at 16 19 32" src="https://user-images.githubusercontent.com/1092138/188659558-24f4ceba-829a-498f-89f4-2c62bd8f6122.png">
<img width="139" alt="Screenshot 2022-09-06 at 16 19 38" src="https://user-images.githubusercontent.com/1092138/188659600-f05e84a0-5606-4909-82e2-5028a431d143.png">



