### PR TITLE
Display a color picker when name colors are not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,7 +389,20 @@ Please note, that as stated in section `Deploy in production`, there is an addit
       "walkSpeed": 180,
       "runSpeed": 720,
       "sensorNearDistance": 75, // Distance required before starting a call with an user
-      "sensorFarDistance": 85 // Distance required before closing a call with an user
+      "sensorFarDistance": 85, // Distance required before closing a call with an user
+      "nameColors": { // Colors available for user name (shown in the dropdown list in the user profile), if not provided a color picker is displayed
+        "white": ["0xffffff", "0xffffff", "0xffffff", "0xffffff"], // A color gradient is set using the following order: [topLeft, topRight, bottomLeft, bottomRight]
+        "orange": ["0xfc9729", "0xfc9729", "0xf69831", "0xf69831"],
+        "red": ["0xf15739", "0xf15739", "0xee5c3b", "0xee5c3b"],
+        "yellow": ["0xf4c918", "0xf4c918", "0xdbb92a", "0xdbb92a"],
+        "beige": ["0xedc993", "0xedc993", "0xe5bf8a", "0xe5bf8a"],
+        "green": ["0xabdf3a", "0xabdf3a", "0xa1cb44", "0xa1cb44"],
+        "lightGreen": ["0x52d8a2", "0x52d8a2", "0x57cfa0", "0x57cfa0"],
+        "blue": ["0x2394d9", "0x2394d9", "0x3199da", "0x3199da"],
+        "lightBlue": ["0xa4e2fb", "0xa4e2fb", "0xa5dbf0", "0xa5dbf0"],
+        "pink": ["0xe584e1", "0xe584e1", "0xf291f0", "0xf291f0"],
+        "purple": ["0xb558e1", "0xb558e1", "0xfa8ff8", "0xfa8ff8"]
+      }
     },
 
     "permissions": {

--- a/core/client/components/character-name-text.js
+++ b/core/client/components/character-name-text.js
@@ -13,17 +13,18 @@ const baselineStyle = {
 };
 
 const defaultTint = 0xFFFFFF;
+const defaultColor = '#fff';
 const baselineOffset = 20;
 const iconMargin = 3;
 
 class CharacterNameText extends Phaser.GameObjects.Container {
-  constructor(scene, name, baseline, tintName) {
+  constructor(scene, name, baseline, color) {
     super(scene);
     this.name = this.createText(name, nameStyle);
     this.nameContainer = new Phaser.GameObjects.Container(scene, 0, 0, [this.name]);
     this.add(this.nameContainer)
       .setBaseline(baseline)
-      .setTintFromName(tintName)
+      .setColor(color)
       .setDepth(99999);
     scene.add.existing(this);
   }
@@ -43,13 +44,16 @@ class CharacterNameText extends Phaser.GameObjects.Container {
     return this;
   }
 
-  setTintFromName(tintName) {
-    const colors = Meteor.settings.public.character.nameColors;
-    if (!colors) return this;
-
-    const color = colors[tintName] || [defaultTint];
-    this.name.setTint(...color);
-    if (this.baseline) this.baseline.setTint(...color);
+  setColor(color) {
+    const tints = Meteor.settings.public.character.nameColors;
+    if (tints) {
+      const tint = tints[color] || [defaultTint];
+      this.name.setTint(...tint);
+      if (this.baseline) this.baseline.setTint(...tint);
+    } else {
+      this.name.setColor(color || defaultColor);
+      if (this.baseline) this.baseline.setColor(color);
+    }
     return this;
   }
 

--- a/core/client/scenes/scene-ui.js
+++ b/core/client/scenes/scene-ui.js
@@ -110,17 +110,17 @@ UIScene = new Phaser.Class({
     this.characterNamesObjects[userId].setIcon(icon);
   },
 
-  updateUserName(userId, name, baseline, colorName) {
+  updateUserName(userId, name, baseline, color) {
     let textInstance = this.characterNamesObjects[userId];
 
     if (!textInstance) {
       const player = userManager.getCharacter(userId);
       if (!player) return;
 
-      textInstance = new CharacterNameText(this, name, baseline, colorName);
+      textInstance = new CharacterNameText(this, name, baseline, color);
       textInstance.player = player;
       this.characterNamesObjects[userId] = textInstance;
-    } else if (textInstance) textInstance.setTintFromName(colorName).setText(name, baseline);
+    } else if (textInstance) textInstance.setColor(color).setText(name, baseline);
   },
 
   destroyUserName(userId) {

--- a/core/client/ui/settings-basic.hbs.html
+++ b/core/client/ui/settings-basic.hbs.html
@@ -28,12 +28,14 @@
         <input type="text" name="baseline" id="baseline" class="js-name input" value="{{currentUser.profile.baseline}}">
       </div>
 
-      {{#if length nameColors}}
         <div class="form-element-m">
           <label for="name-color" class="label">Name color</label>
-          {{> characterNameColorSelector colors=nameColors}}
+          {{#if length nameColors}}
+            {{> characterNameColorSelector colors=nameColors}}
+          {{else}}
+            <input type="color" name="nameColor" id="nameColor" class="js-name-color input" value="{{currentUser.profile.nameColor}}">
+          {{/if}}
         </div>
-      {{/if}}
 
       <div class="form-element-m">
         <label for="website" class="label">Website</label>


### PR DESCRIPTION
When `profile.public.character.namesColor` is not set a color picker is displayed, allowing to select any arbitrary color.

![color_picker](https://user-images.githubusercontent.com/1092138/189693516-e246faf4-e874-44dc-8a01-a6a75d6a65be.gif)

For instance, when profile edition is disabled, it allows admins to set any hex color for the users.
